### PR TITLE
Added nav to view record page and redirected login page to correct route

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,29 +4,24 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import FamilyMemberLog from './components/FamilyMemberLog';
 
-const linkElement = screen.getByText((content, node) => {
-  const hasText = (node) => node.textContent === 'Sign in';
-  const nodeHasText = hasText(node);
-  const childrenDontHaveText = Array.from(node.children).every(
-    (child) => !hasText(child)
+test('renders home page', () => {
+  render(
+    <App />
   );
+  const homeElement = screen.getByText(/Welcome to your vaccine manager/i);
+  expect(homeElement).toBeInTheDocument();
+})
 
-  return nodeHasText && childrenDontHaveText;
-});
-{/*test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText('Sign in', {exact: true});
-  expect(linkElement).toBeInTheDocument();
-});
-*/}
 
 test('renders family member log page', () => {
   render(
-  <Router> 
-    <FamilyMemberLog />
-  </Router>
+    <Router>
+      <FamilyMemberLog />
+    </Router>
   );
-  const linkElement = screen.getByText(/Family Member Log/i);
 
-  expect(linkElement).toBeInTheDocument();
+
+  const logElement = screen.getByText(/Family Member Log/i);
+
+  expect(logElement).toBeInTheDocument();
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,16 +1,31 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
 import FamilyMemberLog from './components/FamilyMemberLog';
 
-test('renders learn react link', () => {
+const linkElement = screen.getByText((content, node) => {
+  const hasText = (node) => node.textContent === 'Sign in';
+  const nodeHasText = hasText(node);
+  const childrenDontHaveText = Array.from(node.children).every(
+    (child) => !hasText(child)
+  );
+
+  return nodeHasText && childrenDontHaveText;
+});
+{/*test('renders learn react link', () => {
   render(<App />);
   const linkElement = screen.getByText('Sign in', {exact: true});
   expect(linkElement).toBeInTheDocument();
 });
+*/}
 
 test('renders family member log page', () => {
-  render(<FamilyMemberLog />);
+  render(
+  <Router> 
+    <FamilyMemberLog />
+  </Router>
+  );
   const linkElement = screen.getByText(/Family Member Log/i);
 
   expect(linkElement).toBeInTheDocument();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,8 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Login />} />
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login />} />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/familyMemberLog" element={<FamilyMemberLog />} />

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -133,7 +133,7 @@ function Login () {
    
   return (
     <div>
-      <h1>Home</h1>
+  
       <SignInSide />
     </div>
   );

--- a/frontend/src/components/ResponsiveAppBar.tsx
+++ b/frontend/src/components/ResponsiveAppBar.tsx
@@ -12,7 +12,7 @@ import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import AdbIcon from '@mui/icons-material/Adb';
-// import { Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import VaccinesIcon from '@mui/icons-material/Vaccines';
 
 const pages = ['Home', 'About', 'Contact', 'Log Out'];
@@ -91,7 +91,9 @@ function ResponsiveAppBar() {
             >
               {pages.map((page) => (
                 <MenuItem key={page} onClick={handleCloseNavMenu}>
+                  <Link to={`/${page.toLowerCase()}`}>
                   <Typography textAlign="center">{page}</Typography>
+                  </Link>
                 </MenuItem>
               ))}
             </Menu>
@@ -122,7 +124,9 @@ function ResponsiveAppBar() {
                 onClick={handleCloseNavMenu}
                 sx={{ my: 2, color: 'white', display: 'block' }}
               >
+              <Link to={`/${page.toLowerCase()}`}>
                 {page}
+              </Link>
               </Button>
             ))}
           </Box>
@@ -151,7 +155,9 @@ function ResponsiveAppBar() {
             >
               {settings.map((setting) => (
                 <MenuItem key={setting} onClick={handleCloseUserMenu}>
+                  <Link to={`/${setting.toLowerCase()}`}>
                   <Typography textAlign="center">{setting}</Typography>
+                  </Link>
                 </MenuItem>
               ))}
             </Menu>

--- a/frontend/src/components/ViewRecord.tsx
+++ b/frontend/src/components/ViewRecord.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import ResponsiveAppBar from "./ResponsiveAppBar";
 
 function ViewRecord() {
   return (
     <div>
+      <ResponsiveAppBar />
       <h1>View Record</h1>
+      
     </div>
   );
 }


### PR DESCRIPTION
Added the responsive nav bar component to /view record endpoint. Redirected routing of login form to /login endpoint. Currently have localhost:300 and localhost:300 display same homepage. Will add linked cards to homepage next as a method to navigate to endpoints not in nav bar.