### PR TITLE
fix: add required packages field to pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
The pnpm-workspace.yaml file was missing the required 'packages' field, causing CI to fail with "packages field missing or empty" error. Added packages field with '.' to indicate the root package.