### PR TITLE
Add Open Graph and Twitter meta tags for social sharing

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -42,6 +42,19 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="Track vaccination records for you and your family - local-first, privacy-focused"
         />
         <meta name="theme-color" content="#0f274a" />
+
+        {/* Open Graph / Facebook */}
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="Vaccine Manager" />
+        <meta property="og:description" content="Track vaccination records for you and your family - local-first, privacy-focused" />
+        <meta property="og:image" content="/favicon.svg" />
+
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Vaccine Manager" />
+        <meta name="twitter:description" content="Track vaccination records for you and your family - local-first, privacy-focused" />
+        <meta name="twitter:image" content="/favicon.svg" />
+
         <link rel="manifest" href="/manifest.json" />
         <Meta />
         <Links />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -45,15 +45,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
         {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://vaccinemanager.org" />
         <meta property="og:title" content="Vaccine Manager" />
         <meta property="og:description" content="Track vaccination records for you and your family - local-first, privacy-focused" />
-        <meta property="og:image" content="/favicon.svg" />
+        <meta property="og:image" content="https://vaccinemanager.org/favicon.svg" />
 
         {/* Twitter */}
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:title" content="Vaccine Manager" />
         <meta name="twitter:description" content="Track vaccination records for you and your family - local-first, privacy-focused" />
-        <meta name="twitter:image" content="/favicon.svg" />
+        <meta name="twitter:image" content="https://vaccinemanager.org/favicon.svg" />
 
         <link rel="manifest" href="/manifest.json" />
         <Meta />


### PR DESCRIPTION
## Summary
Added Open Graph and Twitter meta tags to improve social media sharing and preview generation for the Vaccine Manager application.

## Changes
- Added Open Graph meta tags (`og:type`, `og:title`, `og:description`, `og:image`) to enable rich previews when the site is shared on Facebook and other platforms that support OG tags
- Added Twitter Card meta tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`) to optimize sharing on Twitter/X with proper preview formatting
- Used consistent messaging across all social meta tags matching the existing application description
- Set favicon.svg as the preview image for both Open Graph and Twitter sharing

## Details
These meta tags enable proper social media integration by providing structured metadata that platforms like Facebook, Twitter, and LinkedIn use to generate rich preview cards when users share links to the application. This improves user experience and click-through rates when the app is shared on social networks.